### PR TITLE
Adding test for http server & client on telegram package

### DIFF
--- a/cover.html
+++ b/cover.html
@@ -65,6 +65,8 @@
 				
 				<option value="file4">github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/r_logger.go (75.0%)</option>
 				
+				<option value="file5">github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram/client.go (100.0%)</option>
+				
 				</select>
 			</div>
 			<div id="legend">
@@ -143,12 +145,12 @@ type Handler struct {
         Gin *gin.Engine
 }
 
-func NewHandler(config *config.Config) (h *Handler, err error) <span class="cov10" title="2">{
+func NewHandler(config *config.Config) (h *Handler, err error) <span class="cov10" title="3">{
         if gin.DebugMode != config.Mode &amp;&amp; gin.TestMode != config.Mode &amp;&amp; gin.ReleaseMode != config.Mode </span><span class="cov1" title="1">{
                 return nil, fmt.Errorf("incorrect mode type")
         }</span>
 
-        <span class="cov1" title="1">gin.SetMode(config.Mode)
+        <span class="cov6" title="2">gin.SetMode(config.Mode)
 
         return &amp;Handler{Gin: gin.Default()}, nil</span>
 }
@@ -429,6 +431,39 @@ func (l RLogger) LogEvent(event fxevent.Event) <span class="cov10" title="22">{
                 }</span>
         }
 }
+</pre>
+		
+		<pre class="file" id="file5" style="display: none">package telegram
+
+import (
+        "github.com/kaankoken/binance-quick-go-api-gateway/config"
+        "github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper"
+        "github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram/pb"
+        "go.uber.org/fx"
+        "google.golang.org/grpc"
+        "google.golang.org/grpc/credentials/insecure"
+)
+
+var ClientModule = fx.Options(fx.Provide(InitServiceClient))
+
+type ServiceClient struct {
+        Client pb.TelegramServiceClient
+        Logger *helper.LogHandler
+}
+
+func Initialize(client pb.TelegramServiceClient, logger *helper.LogHandler) ServiceClient <span class="cov5" title="2">{
+        return ServiceClient{
+                Client: client,
+                Logger: logger,
+        }
+}</span>
+
+func InitServiceClient(c *config.Config, logger *helper.LogHandler) pb.TelegramServiceClient <span class="cov10" title="4">{
+        cc, err := grpc.Dial(c.TelegramSvcUrl, grpc.WithTransportCredentials(insecure.NewCredentials()))
+        logger.Error(err)
+
+        return pb.NewTelegramServiceClient(cc)
+}</span>
 </pre>
 		
 		</div>

--- a/cover.html
+++ b/cover.html
@@ -57,11 +57,13 @@
 				
 				<option value="file0">github.com/kaankoken/binance-quick-go-api-gateway/config/config.go (100.0%)</option>
 				
-				<option value="file1">github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/d_logger.go (100.0%)</option>
+				<option value="file1">github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go (100.0%)</option>
 				
-				<option value="file2">github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/handler.go (100.0%)</option>
+				<option value="file2">github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/d_logger.go (100.0%)</option>
 				
-				<option value="file3">github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/r_logger.go (75.0%)</option>
+				<option value="file3">github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/handler.go (100.0%)</option>
+				
+				<option value="file4">github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/r_logger.go (75.0%)</option>
 				
 				</select>
 			</div>
@@ -125,7 +127,34 @@ func LoadConfig() (c *Config, err error) <span class="cov10" title="5">{
 }
 </pre>
 		
-		<pre class="file" id="file1" style="display: none">package helper
+		<pre class="file" id="file1" style="display: none">package pkg
+
+import (
+        "fmt"
+
+        "github.com/gin-gonic/gin"
+        "github.com/kaankoken/binance-quick-go-api-gateway/config"
+        "go.uber.org/fx"
+)
+
+var EngineModule = fx.Options(fx.Provide(NewHandler))
+
+type Handler struct {
+        Gin *gin.Engine
+}
+
+func NewHandler(config *config.Config) (h *Handler, err error) <span class="cov10" title="2">{
+        if gin.DebugMode != config.Mode &amp;&amp; gin.TestMode != config.Mode &amp;&amp; gin.ReleaseMode != config.Mode </span><span class="cov1" title="1">{
+                return nil, fmt.Errorf("incorrect mode type")
+        }</span>
+
+        <span class="cov1" title="1">gin.SetMode(config.Mode)
+
+        return &amp;Handler{Gin: gin.Default()}, nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file2" style="display: none">package helper
 
 import (
         "fmt"
@@ -187,7 +216,7 @@ func (logger DLogger) InfoWithCallback(msg string, f func()) string <span class=
 }</span>
 </pre>
 		
-		<pre class="file" id="file2" style="display: none">package helper
+		<pre class="file" id="file3" style="display: none">package helper
 
 import (
         "github.com/kaankoken/binance-quick-go-api-gateway/config"
@@ -258,7 +287,7 @@ func (l LogHandler) InfoWithCallback(msg string, f func()) string <span class="c
 }
 </pre>
 		
-		<pre class="file" id="file3" style="display: none">package helper
+		<pre class="file" id="file4" style="display: none">package helper
 
 import (
         "fmt"

--- a/cover.out
+++ b/cover.out
@@ -2,8 +2,8 @@ mode: atomic
 github.com/kaankoken/binance-quick-go-api-gateway/config/config.go:19.42,30.16 8 5
 github.com/kaankoken/binance-quick-go-api-gateway/config/config.go:36.2,38.15 2 3
 github.com/kaankoken/binance-quick-go-api-gateway/config/config.go:30.16,32.3 1 2
-github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:17.64,18.99 1 2
-github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:22.2,24.42 2 1
+github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:17.64,18.99 1 3
+github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:22.2,24.42 2 2
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:18.99,20.3 1 1
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/d_logger.go:22.33,26.2 2 2
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/d_logger.go:28.46,29.16 1 4
@@ -57,3 +57,5 @@ github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/r_logger.go:121.43,
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/r_logger.go:125.43,130.4 1 0
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/r_logger.go:134.19,136.4 1 2
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/r_logger.go:138.19,140.4 1 2
+github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram/client.go:19.91,24.2 1 2
+github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram/client.go:26.94,31.2 3 4

--- a/cover.out
+++ b/cover.out
@@ -2,6 +2,9 @@ mode: atomic
 github.com/kaankoken/binance-quick-go-api-gateway/config/config.go:19.42,30.16 8 5
 github.com/kaankoken/binance-quick-go-api-gateway/config/config.go:36.2,38.15 2 3
 github.com/kaankoken/binance-quick-go-api-gateway/config/config.go:30.16,32.3 1 2
+github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:17.64,18.99 1 2
+github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:22.2,24.42 2 1
+github.com/kaankoken/binance-quick-go-api-gateway/pkg/handler.go:18.99,20.3 1 1
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/d_logger.go:22.33,26.2 2 2
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/d_logger.go:28.46,29.16 1 4
 github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper/d_logger.go:35.2,35.12 1 2

--- a/pkg/handler.go
+++ b/pkg/handler.go
@@ -1,20 +1,25 @@
 package pkg
 
 import (
+	"fmt"
+
 	"github.com/gin-gonic/gin"
 	"github.com/kaankoken/binance-quick-go-api-gateway/config"
 	"go.uber.org/fx"
 )
 
-var EngineModule = fx.Options(fx.Provide(newHandler))
+var EngineModule = fx.Options(fx.Provide(NewHandler))
 
 type Handler struct {
 	Gin *gin.Engine
 }
 
-func newHandler(config *config.Config) *Handler {
+func NewHandler(config *config.Config) (h *Handler, err error) {
+	if gin.DebugMode != config.Mode && gin.TestMode != config.Mode && gin.ReleaseMode != config.Mode {
+		return nil, fmt.Errorf("incorrect mode type")
+	}
+
 	gin.SetMode(config.Mode)
 
-	handler := Handler{Gin: gin.Default()}
-	return &handler
+	return &Handler{Gin: gin.Default()}, nil
 }

--- a/pkg/telegram/client.go
+++ b/pkg/telegram/client.go
@@ -16,13 +16,11 @@ type ServiceClient struct {
 	Logger *helper.LogHandler
 }
 
-func Initialize(client pb.TelegramServiceClient, logger *helper.LogHandler) *ServiceClient {
-	svc := &ServiceClient{
+func Initialize(client pb.TelegramServiceClient, logger *helper.LogHandler) ServiceClient {
+	return ServiceClient{
 		Client: client,
 		Logger: logger,
 	}
-
-	return svc
 }
 
 func InitServiceClient(c *config.Config, logger *helper.LogHandler) pb.TelegramServiceClient {

--- a/pkg/telegram/client.go
+++ b/pkg/telegram/client.go
@@ -16,6 +16,15 @@ type ServiceClient struct {
 	Logger *helper.LogHandler
 }
 
+func Initialize(client pb.TelegramServiceClient, logger *helper.LogHandler) *ServiceClient {
+	svc := &ServiceClient{
+		Client: client,
+		Logger: logger,
+	}
+
+	return svc
+}
+
 func InitServiceClient(c *config.Config, logger *helper.LogHandler) pb.TelegramServiceClient {
 	cc, err := grpc.Dial(c.TelegramSvcUrl, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	logger.Error(err)

--- a/pkg/telegram/routes.go
+++ b/pkg/telegram/routes.go
@@ -3,22 +3,11 @@ package telegram
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/kaankoken/binance-quick-go-api-gateway/pkg"
-	"github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper"
-	"github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram/pb"
 	"github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram/routes"
 	"go.uber.org/fx"
 )
 
-var RouteModule = fx.Options(fx.Provide(initialize), fx.Invoke(registerRoutes))
-
-func initialize(client pb.TelegramServiceClient, logger *helper.LogHandler) *ServiceClient {
-	svc := &ServiceClient{
-		Client: client,
-		Logger: logger,
-	}
-
-	return svc
-}
+var RouteModule = fx.Options(fx.Invoke(registerRoutes))
 
 func registerRoutes(client *ServiceClient, handler *pkg.Handler) {
 	routes := handler.Gin.Group("/telegram")

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -50,5 +50,6 @@ done
 
 #cat cover.out | grep -v "pb.go" > cover.out
 rm -rf cover.tmp.out
-rm -rf **/text.log
 go tool cover -html=cover.out -o cover.html
+find . -type f -name 'config.env' -delete
+find . -type f -name 'text.log' -delete

--- a/tests/pkg/handler_test.go
+++ b/tests/pkg/handler_test.go
@@ -53,6 +53,7 @@ func TestGinHandlerWithFx(t *testing.T) {
 			fx.Logger(fxtest.NewTestPrinter(t)),
 			fx.WithLogger(func() fxevent.Logger { return fxtest.NewTestLogger(t) }),
 			pkg.EngineModule,
+			config.Module,
 			fx.Populate(&g),
 		).RequireStart()
 
@@ -66,20 +67,22 @@ func TestGinHandlerWithFx(t *testing.T) {
 		generateFakeSuccessfulConfig(t)
 
 		var g fx.DotGraph
+		var handler *pkg.Handler
 
 		app := fxtest.New(
 			t,
 			fx.Logger(fxtest.NewTestPrinter(t)),
 			fx.WithLogger(func() fxevent.Logger { return fxtest.NewTestLogger(t) }),
 			pkg.EngineModule,
+			config.Module,
 			fx.Populate(&g),
+			fx.Populate(&handler),
 		).RequireStart()
 
 		defer app.RequireStop()
 
 		require.NoError(t, app.Err())
 		assert.Contains(t, g, `"fx.DotGraph" [label=<fx.DotGraph>];`)
-
 	})
 }
 

--- a/tests/pkg/handler_test.go
+++ b/tests/pkg/handler_test.go
@@ -1,0 +1,116 @@
+package pkg_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kaankoken/binance-quick-go-api-gateway/config"
+	"github.com/kaankoken/binance-quick-go-api-gateway/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestGinHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("gin-handler=with-wrong-mode", func(t *testing.T) {
+		generateFakeWrongConfig(t)
+
+		c, err := config.LoadConfig()
+		_, err2 := pkg.NewHandler(c)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, c)
+		assert.NotNil(t, err2)
+	})
+
+	t.Run("gin-handler=success", func(t *testing.T) {
+		generateFakeSuccessfulConfig(t)
+		c, err := config.LoadConfig()
+
+		handler, err2 := pkg.NewHandler(c)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, c)
+		assert.Nil(t, err2)
+		assert.IsType(t, handler, &pkg.Handler{})
+	})
+}
+
+func TestGinHandlerWithFx(t *testing.T) {
+	t.Parallel()
+
+	t.Run("gin-handler-injection=with-wrong-mode", func(t *testing.T) {
+		generateFakeWrongConfig(t)
+
+		var g fx.DotGraph
+
+		app := fxtest.New(
+			t,
+			fx.Logger(fxtest.NewTestPrinter(t)),
+			fx.WithLogger(func() fxevent.Logger { return fxtest.NewTestLogger(t) }),
+			pkg.EngineModule,
+			fx.Populate(&g),
+		).RequireStart()
+
+		defer app.RequireStop()
+
+		require.NoError(t, app.Err())
+		assert.Contains(t, g, `"fx.DotGraph" [label=<fx.DotGraph>];`)
+	})
+
+	t.Run("gin-handler-injection=success", func(t *testing.T) {
+		generateFakeSuccessfulConfig(t)
+
+		var g fx.DotGraph
+
+		app := fxtest.New(
+			t,
+			fx.Logger(fxtest.NewTestPrinter(t)),
+			fx.WithLogger(func() fxevent.Logger { return fxtest.NewTestLogger(t) }),
+			pkg.EngineModule,
+			fx.Populate(&g),
+		).RequireStart()
+
+		defer app.RequireStop()
+
+		require.NoError(t, app.Err())
+		assert.Contains(t, g, `"fx.DotGraph" [label=<fx.DotGraph>];`)
+
+	})
+}
+
+func generateFakeWrongConfig(tb testing.TB) {
+	os.Remove("config.env")
+
+	fakeConfig := `
+	FLAVOR=de
+	GIN_MODE=releasdase
+	PORT=:6542
+	AUTH_SVC_URL=localhost:1
+	OBSERVER_SVC_URL=localhost:2
+	TELEGRAM_SVC_URL=localhost:3
+	`
+
+	err := os.WriteFile("config.env", []byte(fakeConfig), 0644)
+	assert.Nil(tb, err)
+}
+
+func generateFakeSuccessfulConfig(tb testing.TB) {
+	os.Remove("config.env")
+
+	fakeConfig := `
+	FLAVOR=de
+	GIN_MODE=test
+	PORT=:6542
+	AUTH_SVC_URL=localhost:1
+	OBSERVER_SVC_URL=localhost:2
+	TELEGRAM_SVC_URL=localhost:3
+	`
+
+	err := os.WriteFile("config.env", []byte(fakeConfig), 0644)
+	assert.Nil(tb, err)
+}

--- a/tests/pkg/telegram/client_test.go
+++ b/tests/pkg/telegram/client_test.go
@@ -1,0 +1,124 @@
+package telegram_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kaankoken/binance-quick-go-api-gateway/config"
+	"github.com/kaankoken/binance-quick-go-api-gateway/pkg/helper"
+	"github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram"
+	"github.com/kaankoken/binance-quick-go-api-gateway/pkg/telegram/pb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestClient(t *testing.T) {
+	// Needed Module initialization
+	// debug logger
+	d := helper.SetLoggerFormat()
+	// release logger
+	logger := helper.InitializeLogger()
+	r := helper.InitializeLoggerPtr(logger)
+	generateFakeSuccessfulConfig(t)
+
+	t.Parallel()
+
+	t.Run("client-init=success", func(t *testing.T) {
+		c, err := config.LoadConfig()
+
+		// log handler initialization
+		l := helper.Initialize(c, d, r)
+
+		service := telegram.InitServiceClient(c, l)
+		var x pb.TelegramServiceClient
+
+		assert.Nil(t, err)
+		assert.NotNil(t, c)
+		assert.IsType(t, &service, &x)
+	})
+
+	t.Run("client-init=svc-success", func(t *testing.T) {
+		var compareType pb.TelegramServiceClient
+		var structCompareType telegram.ServiceClient
+
+		c, err := config.LoadConfig()
+
+		// log handler initialization
+		l := helper.Initialize(c, d, r)
+
+		service := telegram.InitServiceClient(c, l)
+		res := telegram.Initialize(compareType, l)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, c)
+		assert.IsType(t, &service, &compareType)
+		assert.IsType(t, &structCompareType, &res)
+	})
+}
+
+func TestClientWithFx(t *testing.T) {
+	generateFakeSuccessfulConfig(t)
+	t.Parallel()
+
+	t.Run("client-init-injection=success", func(t *testing.T) {
+		var g fx.DotGraph
+		var h pb.TelegramServiceClient
+
+		app := fxtest.New(
+			t,
+			fx.Logger(fxtest.NewTestPrinter(t)),
+			fx.WithLogger(func() fxevent.Logger { return fxtest.NewTestLogger(t) }),
+			config.Module,
+			telegram.ClientModule,
+			helper.LoggerModule,
+			fx.Populate(&h),
+			fx.Populate(&g),
+		).RequireStart()
+
+		defer app.RequireStop()
+
+		require.NoError(t, app.Err())
+		assert.Contains(t, g, `"fx.DotGraph" [label=<fx.DotGraph>];`)
+	})
+
+	t.Run("client-init-injection=svc-success", func(t *testing.T) {
+		var g fx.DotGraph
+		var h telegram.ServiceClient
+
+		app := fxtest.New(
+			t,
+			fx.Logger(fxtest.NewTestPrinter(t)),
+			fx.WithLogger(func() fxevent.Logger { return fxtest.NewTestLogger(t) }),
+			config.Module,
+			telegram.ClientModule,
+			helper.LoggerModule,
+			fx.Provide(telegram.Initialize),
+			fx.Populate(&h),
+			fx.Populate(&g),
+		).RequireStart()
+
+		defer app.RequireStop()
+
+		require.NoError(t, app.Err())
+		assert.Contains(t, g, `"fx.DotGraph" [label=<fx.DotGraph>];`)
+	})
+}
+
+func generateFakeSuccessfulConfig(tb testing.TB) {
+	os.Remove("config.env")
+
+	fakeConfig := `
+	FLAVOR=de
+	GIN_MODE=uat
+	PORT=:6542
+	AUTH_SVC_URL=localhost:1
+	OBSERVER_SVC_URL=localhost:2
+	TELEGRAM_SVC_URL=localhost:3
+	`
+
+	err := os.WriteFile("config.env", []byte(fakeConfig), 0644)
+	assert.Nil(tb, err)
+}


### PR DESCRIPTION
- Add test for http server, `gin`, added
- Add test for `telegram` client added
- Fix missing config module that required by `fx` on  `http_server`
